### PR TITLE
Fix Firebase storage bucket url

### DIFF
--- a/frontend/src/services/firebase.js
+++ b/frontend/src/services/firebase.js
@@ -9,7 +9,10 @@ const firebaseConfig = {
     apiKey: "AIzaSyAnlMW-lOQg3YmssadJp86apbtnokeu_8s",
     authDomain: "indexador-demo-gemini.firebaseapp.com",
     projectId: "indexador-demo-gemini",
-    storageBucket: "indexador-demo-gemini.firebasestorage.app",
+    // The storage bucket URL must end with 'appspot.com'. The previous
+    // value used the domain `firebasestorage.app`, which prevents the
+    // Firebase SDK from correctly locating the bucket.
+    storageBucket: "indexador-demo-gemini.appspot.com",
     messagingSenderId: "1054037908225",
     appId: "1:1054037908225:web:cf279981cb093e3a19d900"
   };


### PR DESCRIPTION
## Summary
- fix incorrect Firebase storage bucket URL that prevented use of Storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841cc562260832ca988c6ead4494321