### PR TITLE
Fix token handling in React auth flow

### DIFF
--- a/frontend/src/components/Signup.jsx
+++ b/frontend/src/components/Signup.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
-import { authAPI } from '../services/api';
 import { Link, useNavigate } from 'react-router-dom';
 
 export default function Signup() {
@@ -29,14 +28,6 @@ export default function Signup() {
       
       // Register with Firebase
       await signup(email, password);
-      
-      // Also register with our backend
-      try {
-        await authAPI.register(email, password);
-      } catch (backendError) {
-        console.warn('Backend registration failed:', backendError.message);
-        // Continue anyway since Firebase registration succeeded
-      }
       
       navigate('/dashboard');
     } catch (error) {

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -25,6 +25,9 @@ export function AuthProvider({ children }) {
     }
     try {
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+      const token = await userCredential.user.getIdToken();
+      setIdToken(token);
+      localStorage.setItem('idToken', token);
       return userCredential;
     } catch (error) {
       throw error;
@@ -38,6 +41,9 @@ export function AuthProvider({ children }) {
     }
     try {
       const userCredential = await signInWithEmailAndPassword(auth, email, password);
+      const token = await userCredential.user.getIdToken();
+      setIdToken(token);
+      localStorage.setItem('idToken', token);
       return userCredential;
     } catch (error) {
       throw error;


### PR DESCRIPTION
## Summary
- sync token retrieval in `signup` and `login`
- avoid duplicate backend registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841d07c9030832c97cbbce608e7201f